### PR TITLE
Single message API for `Simple Topic Producer`

### DIFF
--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -3,6 +3,7 @@ object Versions {
     const val kotlin = "1.4.10"
     const val `kotlinx-coroutines` = "1.3.9"
     const val scalaBinary = "2.13"
+    const val akkaStreamKafka = "2.0.5"
     const val lagom = "1.6.2"
     const val lagomPac4j = "2.1.0"
     const val play = "2.8.1"

--- a/java/build.gradle.kts
+++ b/java/build.gradle.kts
@@ -22,6 +22,17 @@ compileTestKotlin.kotlinOptions.freeCompilerArgs += "-Xjvm-default=enable"
 dependencies {
     implementation(kotlin("stdlib-jdk8"))
     implementation(kotlin("reflect"))
+    when (scalaBinaryVersion) {
+        "2.12" -> {
+            implementation("org.scala-lang:scala-library") {
+                version {
+                    // Workaround of https://youtrack.jetbrains.com/issue/KT-38325#focus=Comments-27-4492387.0-0
+                    strictly("2.12.10")
+                }
+            }
+        }
+    }
+    implementation("com.typesafe.akka", "akka-stream-kafka_$scalaBinaryVersion", Versions.akkaStreamKafka)
     compileOnly("com.lightbend.lagom", "lagom-javadsl-api_$scalaBinaryVersion", lagomVersion)
     compileOnly("com.lightbend.lagom", "lagom-javadsl-server_$scalaBinaryVersion", lagomVersion)
     compileOnly("com.lightbend.lagom", "lagom-javadsl-kafka-client_$scalaBinaryVersion", lagomVersion)

--- a/java/src/test/java/org/taymyr/lagom/javadsl/broker/TestTopicPublisher.java
+++ b/java/src/test/java/org/taymyr/lagom/javadsl/broker/TestTopicPublisher.java
@@ -14,11 +14,14 @@ public interface TestTopicPublisher extends Service {
 
     ServiceCall<NotUsed, NotUsed> publishWithKey(String msg);
 
+    ServiceCall<NotUsed, NotUsed> enqueueToPublish(String msg);
+
     @Override
     default Descriptor descriptor() {
         return named("test-topic-publisher").withCalls(
             pathCall("/test-topic-publisher/without-key/:msg", this::publishWithoutKey),
-            pathCall("/test-topic-publisher/with-key/:key", this::publishWithKey)
+            pathCall("/test-topic-publisher/with-key/:key", this::publishWithKey),
+            pathCall("/test-topic-publisher/with-key/enqueue/:key", this::enqueueToPublish)
         ).withAutoAcl(true);
     }
 }

--- a/java/src/test/java/org/taymyr/lagom/javadsl/broker/TestTopicPublisherImpl.java
+++ b/java/src/test/java/org/taymyr/lagom/javadsl/broker/TestTopicPublisherImpl.java
@@ -2,10 +2,12 @@ package org.taymyr.lagom.javadsl.broker;
 
 import akka.NotUsed;
 import com.lightbend.lagom.javadsl.api.ServiceCall;
+
 import javax.inject.Inject;
 
-class TestTopicPublisherImpl implements TestTopicPublisher {
+import static akka.NotUsed.notUsed;
 
+class TestTopicPublisherImpl implements TestTopicPublisher {
     private SimpleTopicProducersRegistry simpleTopicProducersRegistry;
 
     @Inject
@@ -15,15 +17,19 @@ class TestTopicPublisherImpl implements TestTopicPublisher {
 
     @Override
     public ServiceCall<NotUsed, NotUsed> publishWithoutKey(String msg) {
-        return notUsed ->
-                simpleTopicProducersRegistry.get(TestTopicService.TOPIC_WITHOUT_KEYS).publish(msg)
-                    .thenApply( x -> NotUsed.getInstance() );
+        return notUsed -> simpleTopicProducersRegistry.get(TestTopicService.TOPIC_WITHOUT_KEYS).send(msg)
+            .thenApply(x -> notUsed());
     }
 
     @Override
     public ServiceCall<NotUsed, NotUsed> publishWithKey(String msg) {
-        return notUsed ->
-                simpleTopicProducersRegistry.get(TestTopicService.TOPIC_WITH_KEYS).publish(msg)
-                    .thenApply( x -> NotUsed.getInstance() );
+        return notUsed -> simpleTopicProducersRegistry.get(TestTopicService.TOPIC_WITH_KEYS).send(msg)
+            .thenApply(x -> notUsed());
+    }
+
+    @Override
+    public ServiceCall<NotUsed, NotUsed> enqueueToPublish(String msg) {
+        return notUsed -> simpleTopicProducersRegistry.get(TestTopicService.TOPIC_WITH_KEYS).enqueue(msg)
+            .thenApply(x -> notUsed());
     }
 }


### PR DESCRIPTION
Unfortunately since some release the `publish` method of `SimpleTopicProducer` became to enqueue a message. The simple producer is not so simple now :). Moreover using a queue leads to loss of errors while publishing because `QueueResult` doesn't reflect the result of publishing. Sometimes it is very usefull to know about publishing failures directly.
