### PR TITLE
Added the ability to specify the coroutine context

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,28 @@ class TestService @Inject constructor(actorSystem: ActorSystem) : Service, Corou
     }
 }
 ```
+It is also possible to set the coroutine context. To do this, you need to override the value of the `context` property.
+This allows you to set `CoroutineContext.Element`.
+Example of changing the name of a coroutine:
+```kotlin
+class TestService @Inject constructor(actorSystem: ActorSystem) : Service, CoroutineService {
+    
+    override val dispatcher: CoroutineDispatcher = actorSystem.dispatcher.asCoroutineDispatcher()
+
+    override val context: CoroutineContext = CoroutineName("custom-coroutine-name")
+
+    private fun testMethod(): ServiceCall<NotUsed, String> = serviceCall {
+        "Hello, from coroutine!"
+    }
+
+    override fun descriptor(): Descriptor {
+        return Service.named("test-service")
+            .withCalls(
+                Service.restCall<NotUsed, String>(Method.GET, "/test", TestService::testMethod.javaMethod)
+            )
+    }
+}
+```
 ### The Cache API using coroutines (Java &#10007; / Scala &#10007; / Kotlin &#10003;)
 
 `org.taymyr.lagom.kotlindsl.cache.AsyncCacheApi` allows using methods from `play.cache.AsyncCacheApi` along with suspend functions.

--- a/java/src/main/kotlin/org/taymyr/lagom/javadsl/api/CoroutineSecuredService.kt
+++ b/java/src/main/kotlin/org/taymyr/lagom/javadsl/api/CoroutineSecuredService.kt
@@ -17,7 +17,7 @@ interface CoroutineSecuredService : SecuredService, CoroutineService {
      * Starts new coroutine with authorized and returns its result as an implementation of [ServerServiceCall].
      *
      * @param start coroutine start option. The default value is [CoroutineStart.DEFAULT].
-     * @param block he coroutine code.
+     * @param block the coroutine code.
      */
     fun <Request, Response> authorizedServiceCall(
         start: CoroutineStart = CoroutineStart.DEFAULT,
@@ -30,7 +30,7 @@ interface CoroutineSecuredService : SecuredService, CoroutineService {
      * Starts new coroutine with authorized and returns its result as an implementation of [ServerServiceCall].
      *
      * @param start coroutine start option. The default value is [CoroutineStart.DEFAULT].
-     * @param block he coroutine code.
+     * @param block the coroutine code.
      */
     fun <Request, Response> authorizedHeaderServiceCall(
         start: CoroutineStart = CoroutineStart.DEFAULT,
@@ -46,7 +46,7 @@ interface CoroutineSecuredService : SecuredService, CoroutineService {
      * If authentication is failed, the profile will be an instance of [AnonymousProfile].
      *
      * @param start coroutine start option. The default value is [CoroutineStart.DEFAULT].
-     * @param block he coroutine code.
+     * @param block the coroutine code.
      */
     fun <Request, Response> authenticatedServiceCall(
         start: CoroutineStart = CoroutineStart.DEFAULT,
@@ -60,7 +60,7 @@ interface CoroutineSecuredService : SecuredService, CoroutineService {
      * If authentication is failed, the profile will be an instance of [AnonymousProfile].
      *
      * @param start coroutine start option. The default value is [CoroutineStart.DEFAULT].
-     * @param block he coroutine code.
+     * @param block the coroutine code.
      */
     fun <Request, Response> authenticatedHeaderServiceCall(
         start: CoroutineStart = CoroutineStart.DEFAULT,


### PR DESCRIPTION
In my case, it is necessary to be able to specify `CoroutineContext.Element` for the context of the created coroutine in the `serviceCall` method. Therefore, in addition to the coroutine dispatcher, I set the `context` property in the `CoroutineService interface`.