### PR TITLE
add combined request/response logging and MDC context support

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,8 +183,101 @@ configured-ahc-ws-client.logging.presets = [
   }
 ]
 ```
+By default, the logger writes two separate messages (one for the request and one for the response).
+You can configure the logger to combine request and response into a single log entry containing both request and response details.
+```hocon
+configured-ahc-ws-client.logging.request-response-combined = true
+```
 Enjoy!
 
+### MDC context support
+
+The HTTP client logging supports populating the MDC (Mapped Diagnostic Context) with request and response data.
+
+#### Configuring MDC fields
+
+To define which fields are included in the MDC for each HTTP request/response,  
+use the `configured-ahc-ws-client.logging.mdc.default-preset.fields` setting.
+
+If the fields list is empty, no MDC data will be populated.
+
+#### Supported fields
+
+Fields are grouped by logical scope:
+
+- Common — added for both request and response phases.
+- Request — added only during the request phase, before the request is sent.
+- Response — added only during the response phase, after a response is received.
+
+| Scope        | Field name     | Description                                                   |
+|--------------|----------------|---------------------------------------------------------------|
+| **Common**   | correlation-id | Correlation UUID propagated across request and response.      |
+|              | method         | HTTP method (GET, POST, etc.).                                |
+|              | url            | Full request URL.                                             |
+| **Request**  | request-body   | Request body content (truncated by request-body-max-bytes).   |
+| **Response** | status-code    | HTTP status code.                                             |
+|              | duration-ms    | Total request duration in milliseconds.                       |
+|              | response-body  | Response body content (truncated by response-body-max-bytes). |
+
+#### Body size limits
+
+You can optionally control how much of the request and response body is stored in the MDC 
+using the `request-body-max-bytes` and `response-body-max-bytes` settings.
+
+These settings define the maximum number of bytes that will be added to the MDC for the request and response bodies. 
+If the content exceeds the limit, it is safely truncated.  
+The limits are only effective when the corresponding fields (`request-body` or `response-body`) are included in the`fields` list.
+
+#### Example:
+
+```hocon
+configured-ahc-ws-client.logging.mdc.default-preset {
+  fields = [correlation-id, url, request-body, response-body]
+  request-body-max-bytes = 2000
+  response-body-max-bytes = 2000
+}
+```
+
+#### URL-specific MDC presets
+
+In addition to default MDC configuration, you can define URL-specific presets that override default behaviour for certain endpoints.
+Each entry in `configured-ahc-ws-client.logging.mdc.presets` uses the same structure as `configured-ahc-ws-client.logging.mdc.default-preset`,
+but adds an extra field `urls` - a list of regular expressions to match request URLs.
+When a request URL matches any of the listed patterns, the corresponding preset overrides the default MDC configuration fot that request.
+
+Example:
+
+```hocon
+configured-ahc-ws-client.logging.mdc.presets = [
+  {
+    urls = ["/foo"]
+    fields = [correlation-id, request-body, response-body]
+    response-body-max-bytes = 200
+  }
+]
+```
+
+#### MDC key names
+
+To override (rename) default MDC key names in your logs, use the
+`configured-ahc-ws-client.logging.mdc.name-mappings` setting.
+
+#### Example:
+
+```hocon
+configured-ahc-ws-client.logging.mdc.name-mappings {
+   url = endpoint
+}
+```
+
+#### MDC key prefix
+
+To add a prefix to all MDC key names, use:
+
+```hocon
+configured-ahc-ws-client.logging.mdc.name-prefix = "http.client."
+```
+ 
 ### ServiceCall running on coroutines (Java &#10007; / Scala &#10007; / Kotlin &#10003;)
 Using `CoroutineService` you can make requests using coroutines.
 Example:

--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -20,5 +20,54 @@ configured-ahc-ws-client {
     #   urls = ["/foo/([^/][0-9]+)/bar"]
     # }
     presets = []
+    # Whether to combine request and response logs into a single log entry.
+    request-response-combined = false
+
+    mdc {
+      # Default MDC (Mapped Diagnostic Context) preset.
+      # Applied to all requests that do not match any entry from `mdc-presets`.
+      default-preset {
+        # List of fields to include in MDC.
+        # Supported values (grouped by scope):
+        #
+        # Common:
+        #   correlation-id   - Correlation UUID
+        #   method           - HTTP method (GET, POST, etc.)
+        #   url              - Full request URL
+        #
+        # Request:
+        #   request-body     - Request body content (truncated by request-body-max-bytes)
+        #
+        # Response:
+        #   status-code      - HTTP status code
+        #   duration-ms      - Total request duration in milliseconds (captured after response)
+        #   response-body    - Response body content (truncated by response-body-max-bytes)
+        #
+        # Example: [correlation-id, method, url, status-code, duration-ms]
+        fields = []
+
+        # Maximum number of bytes of the request body to store in MDC (truncated if exceeded).
+        request-body-max-bytes = null
+        # Maximum number of bytes of the response body to store in MDC (truncated if exceeded).
+        response-body-max-bytes = null
+      }
+      # URL-specific MDC (Mapped Diagnostic Context) presets.
+      # Each preset overrides the default-mdc-preset for requests matching given URL patterns.
+      # The structure of each preset is identical to default-mdc-preset and
+      # only the urls field is unique to mdc-presets — it defines which request URLs the preset applies to.
+      # See default-mdc-preset above for the list of supported MDC fields and detailed descriptions.
+      presets = []
+      # Prefix applied to all MDC key names.
+      # For example, with "http.client." the resulting MDC entries become:
+      # "http.client.method", "http.client.url".
+      # Set to empty string to disable prefixing.
+      name-prefix = "http.client."
+      # Optional mapping to rename MDC fields.
+      # Example:
+      # mdc-name-mappings = {
+      #   url = endpoint
+      # }
+      name-mappings = {}
+    }
   }
 }

--- a/core/src/main/scala/org/taymyr/lagom/ws/AhcRequestResponseLogger.scala
+++ b/core/src/main/scala/org/taymyr/lagom/ws/AhcRequestResponseLogger.scala
@@ -1,7 +1,16 @@
 package org.taymyr.lagom.ws
 
+import akka.util.ByteString
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
+import org.slf4j.MDC
+import org.taymyr.lagom.ws.AhcRequestResponseLogger.MDC_CORRELATION_ID
+import org.taymyr.lagom.ws.AhcRequestResponseLogger.MDC_DURATION_MS
+import org.taymyr.lagom.ws.AhcRequestResponseLogger.MDC_METHOD
+import org.taymyr.lagom.ws.AhcRequestResponseLogger.MDC_REQUEST_BODY
+import org.taymyr.lagom.ws.AhcRequestResponseLogger.MDC_RESPONSE_BODY
+import org.taymyr.lagom.ws.AhcRequestResponseLogger.MDC_STATUS_CODE
+import org.taymyr.lagom.ws.AhcRequestResponseLogger.MDC_URL
 import play.api.libs.ws.EmptyBody
 import play.api.libs.ws.InMemoryBody
 import play.api.libs.ws.StandaloneWSResponse
@@ -9,7 +18,9 @@ import play.api.libs.ws.WSRequestExecutor
 import play.api.libs.ws.WSRequestFilter
 import play.api.libs.ws.ahc.CurlFormat
 import play.api.libs.ws.ahc.StandaloneAhcWSRequest
+import play.shaded.ahc.org.asynchttpclient.util.HttpUtils
 
+import java.nio.charset.StandardCharsets
 import java.util.UUID
 import java.util.UUID.randomUUID
 import scala.concurrent.ExecutionContext
@@ -19,6 +30,7 @@ class AhcRequestResponseLogger(loggingSettings: LoggingSettings, logger: Logger)
     with CurlFormat {
 
   override def apply(executor: WSRequestExecutor): WSRequestExecutor = WSRequestExecutor { request =>
+    val startTime        = System.nanoTime()
     val eventualResponse = executor(request)
     val correlationId    = randomUUID()
     val r                = request.asInstanceOf[StandaloneAhcWSRequest]
@@ -29,23 +41,94 @@ class AhcRequestResponseLogger(loggingSettings: LoggingSettings, logger: Logger)
       val preset = loggingSettings.presets
         .find { _.urls.exists { _.findFirstIn(url).nonEmpty } }
         .getOrElse(loggingSettings.defaultPreset)
-      logRequest(r, url, correlationId, preset)
-      eventualResponse.map { response =>
-        logResponse(response, url, correlationId, preset)
-        response
+      val mdc = loggingSettings.mdc.presets
+        .find { _.urls.exists { _.findFirstIn(url).nonEmpty } }
+        .getOrElse(loggingSettings.mdc.defaultPreset)
+      if (loggingSettings.requestResponseCombined) {
+        eventualResponse.map { response =>
+          val durationMs = (System.nanoTime() - startTime) / 1000000
+          logRequestResponseCombined(r, response, url, correlationId, durationMs, preset, mdc)
+          response
+        }
+      } else {
+        logRequest(r, r.method, url, correlationId, preset, mdc)
+        eventualResponse.map { response =>
+          val durationMs = (System.nanoTime() - startTime) / 1000000
+          logResponse(response, r.method, url, correlationId, durationMs, preset, mdc)
+          response
+        }
       }
     }
   }
 
   private def logRequest(
       request: StandaloneAhcWSRequest,
+      method: String,
+      url: String,
+      correlationId: UUID,
+      preset: LoggingPreset,
+      mdc: MdcPreset
+  ): Unit = {
+    if (mdc.enabled) {
+      fillMdcCommonContext(method, url, correlationId, mdc)
+      fillMdcRequestContext(request, mdc)
+    }
+    logger.info(createRequestLogMessage(request, url, correlationId, preset))
+    if (mdc.enabled) {
+      clearMdcContext()
+    }
+  }
+
+  private def logResponse(
+      response: StandaloneWSResponse,
+      method: String,
+      url: String,
+      correlationId: UUID,
+      duration: Long,
+      preset: LoggingPreset,
+      mdc: MdcPreset
+  ): Unit = {
+    if (mdc.enabled) {
+      fillMdcCommonContext(method, url, correlationId, mdc)
+      fillMdcResponseContext(response, duration, mdc)
+    }
+    logger.info(createResponseLogMessage(response, url, preset, Option(correlationId)))
+    if (mdc.enabled) {
+      clearMdcContext()
+    }
+  }
+
+  private def logRequestResponseCombined(
+      request: StandaloneAhcWSRequest,
+      response: StandaloneWSResponse,
+      url: String,
+      correlationId: UUID,
+      durationMs: Long,
+      preset: LoggingPreset,
+      mdc: MdcPreset,
+  ): Unit = {
+    val req  = createRequestLogMessage(request, url, correlationId, preset)
+    val resp = createResponseLogMessage(response, url, preset)
+
+    if (mdc.enabled) {
+      fillMdcCommonContext(request.method, url, correlationId, mdc)
+      fillMdcRequestContext(request, mdc)
+      fillMdcResponseContext(response, durationMs, mdc)
+    }
+    logger.info(s"$req\n$resp")
+    if (mdc.enabled) {
+      clearMdcContext()
+    }
+  }
+
+  private def createRequestLogMessage(
+      request: StandaloneAhcWSRequest,
       url: String,
       correlationId: UUID,
       preset: LoggingPreset
-  ): Unit = {
-    val sb = new StringBuilder(s"Request to $url")
-    sb.append("\n")
-      .append(s"Request correlation ID: $correlationId")
+  ): String = {
+    val sb = new StringBuilder(s"Request to $url\n")
+    sb.append(s"Request correlation ID: $correlationId")
       .append("\n")
     if (preset.requestElements.contains("curl")) {
       sb.append(toCurl(request))
@@ -78,20 +161,21 @@ class AhcRequestResponseLogger(loggingSettings: LoggingSettings, logger: Logger)
         case other     => // Do nothing.
       }
     }
-    logger.info(sb.toString())
+    sb.toString()
   }
 
-  private def logResponse(
+  private def createResponseLogMessage(
       response: StandaloneWSResponse,
       url: String,
-      correlationId: UUID,
-      preset: LoggingPreset
-  ): Unit = {
-    val sb = new StringBuilder(s"Response from $url")
-    sb.append("\n")
-      .append(s"Request correlation ID: $correlationId")
-      .append("\n")
-      .append(s"Response actual URI: ${response.uri}")
+      preset: LoggingPreset,
+      correlationId: Option[UUID] = Option.empty,
+  ): String = {
+    val sb = new StringBuilder(s"Response from $url\n")
+    correlationId.foreach(cid =>
+      sb.append(s"Request correlation ID: $cid")
+        .append("\n")
+    )
+    sb.append(s"Response actual URI: ${response.uri}")
       .append("\n")
       .append(s"Response status code: ${response.status}")
       .append("\n")
@@ -126,14 +210,124 @@ class AhcRequestResponseLogger(loggingSettings: LoggingSettings, logger: Logger)
         case None => // do nothing
       }
     }
+    sb.toString()
+  }
 
-    logger.info(sb.toString())
+  private def fillMdcCommonContext(
+      method: String,
+      url: String,
+      correlationId: UUID,
+      mdc: MdcPreset
+  ): Unit = {
+    putMdc(mdc.fields, MDC_CORRELATION_ID, correlationId.toString)
+    putMdc(mdc.fields, MDC_METHOD, method)
+    putMdc(mdc.fields, MDC_URL, url)
+  }
+
+  private def fillMdcRequestContext(request: StandaloneAhcWSRequest, mdc: MdcPreset): Unit = {
+    request.body match {
+      case InMemoryBody(byteString) =>
+        putMdc(
+          mdc.fields,
+          MDC_REQUEST_BODY,
+          () => {
+            val charset = findCharset(request)
+            mdc.requestBodyMaxBytes
+              .map(
+                truncate(byteString, charset, _)
+              )
+              .getOrElse(byteString)
+              .decodeString(charset)
+          }
+        )
+      case EmptyBody => // Do nothing.
+      case other     => // Do nothing.
+    }
+  }
+
+  private def fillMdcResponseContext(
+      response: StandaloneWSResponse,
+      duration: Long,
+      mdc: MdcPreset
+  ): Unit = {
+    putMdc(mdc.fields, MDC_STATUS_CODE, response.status.toString)
+    putMdc(mdc.fields, MDC_DURATION_MS, duration.toString)
+
+    if (mdc.fields.contains(MDC_RESPONSE_BODY)) {
+      Option(response.bodyAsBytes) match {
+        case Some(byteString) =>
+          putMdc(
+            mdc.fields,
+            MDC_RESPONSE_BODY,
+            () => {
+              val charset = findCharset(response)
+              mdc.responseBodyMaxBytes
+                .map(
+                  truncate(byteString, charset, _)
+                )
+                .getOrElse(byteString)
+                .decodeString(charset)
+            }
+          )
+        case None => // do nothing
+      }
+    }
+  }
+
+  private def clearMdcContext(): Unit = {
+    MDC.remove(mdcKey(MDC_CORRELATION_ID))
+    MDC.remove(mdcKey(MDC_METHOD))
+    MDC.remove(mdcKey(MDC_URL))
+    MDC.remove(mdcKey(MDC_STATUS_CODE))
+    MDC.remove(mdcKey(MDC_DURATION_MS))
+    MDC.remove(mdcKey(MDC_REQUEST_BODY))
+    MDC.remove(mdcKey(MDC_RESPONSE_BODY))
+  }
+
+  private def putMdc(fields: Seq[String], key: String, value: () => String): Unit = {
+    if (fields.contains(key)) {
+      MDC.put(mdcKey(key), value())
+    }
+  }
+
+  private def putMdc(fields: Seq[String], key: String, value: String): Unit = {
+    putMdc(fields, key, () => value)
+  }
+
+  private def mdcKey(name: String): String = {
+    val key = loggingSettings.mdc.nameMappings.getOrElse(name, name)
+    s"${loggingSettings.mdc.namePrefix}$key"
+  }
+
+  private def findCharset(request: StandaloneWSResponse): String = {
+    Option(HttpUtils.extractContentTypeCharsetAttribute(request.contentType))
+      .getOrElse {
+        StandardCharsets.UTF_8
+      }
+      .name()
+  }
+
+  private def truncate(body: ByteString, charset: String, maxBytes: Int) = {
+    if (maxBytes > 0 && body.size > maxBytes) {
+      body
+        .take(maxBytes)
+        .concat(ByteString("(message truncated to " + maxBytes + " bytes)", charset))
+    } else {
+      body
+    }
   }
 }
 
 object AhcRequestResponseLogger {
 
-  private val logger = LoggerFactory.getLogger("org.taymyr.lagom.ws.AhcRequestResponseLogger")
+  private val logger             = LoggerFactory.getLogger("org.taymyr.lagom.ws.AhcRequestResponseLogger")
+  private val MDC_CORRELATION_ID = "correlation-id"
+  private val MDC_METHOD         = "method"
+  private val MDC_URL            = "url"
+  private val MDC_STATUS_CODE    = "status-code"
+  private val MDC_DURATION_MS    = "duration-ms"
+  private val MDC_REQUEST_BODY   = "request-body"
+  private val MDC_RESPONSE_BODY  = "response-body"
 
   def apply(loggingSettings: LoggingSettings)(implicit ec: ExecutionContext): AhcRequestResponseLogger =
     new AhcRequestResponseLogger(loggingSettings, logger)

--- a/core/src/main/scala/org/taymyr/lagom/ws/ConfiguredAhcWSClient.scala
+++ b/core/src/main/scala/org/taymyr/lagom/ws/ConfiguredAhcWSClient.scala
@@ -35,9 +35,11 @@ object ConfiguredAhcWSClient {
 
 case class LoggingSettings(
     enabled: Boolean,
+    requestResponseCombined: Boolean,
     skipUrls: Seq[Regex],
     defaultPreset: LoggingPreset,
-    presets: Seq[LoggingPreset]
+    presets: Seq[LoggingPreset],
+    mdc: Mdc
 )
 
 case class LoggingPreset(
@@ -46,13 +48,31 @@ case class LoggingPreset(
     urls: Seq[Regex]
 )
 
+case class Mdc(
+    defaultPreset: MdcPreset,
+    presets: Seq[MdcPreset],
+    nameMappings: Map[String, String],
+    namePrefix: String
+)
+
+case class MdcPreset(
+    urls: Seq[Regex],
+    fields: Seq[String],
+    requestBodyMaxBytes: Option[Int],
+    responseBodyMaxBytes: Option[Int]
+) {
+  val enabled: Boolean = fields.nonEmpty
+}
+
 object LoggingSettings {
 
   def apply(config: Config): LoggingSettings = LoggingSettings(
     config.getBoolean("enabled"),
+    config.getBoolean("request-response-combined"),
     buildStrings(config, "skip-urls").map { _.r },
     buildDefaultPreset(config),
     buildPresets(config),
+    buildMdc(config.getConfig("mdc"))
   )
 
   def buildDefaultPreset(config: Config): LoggingPreset = {
@@ -85,5 +105,42 @@ object LoggingSettings {
       .filter { s =>
         s != null && s.nonEmpty
       }
+  }
+
+  def buildMdc(config: Config): Mdc = {
+    Mdc(
+      defaultPreset = buildMdcPreset(config.getConfig("default-preset"), isDefault = true),
+      presets = buildMdcPresets(config),
+      nameMappings = config
+        .getObject("name-mappings")
+        .keySet()
+        .asScala
+        .map { key =>
+          key -> config.getString("name-mappings." + key)
+        }
+        .toMap,
+      namePrefix = config.getString("name-prefix")
+    )
+  }
+
+  def buildMdcPreset(config: Config, isDefault: Boolean): MdcPreset = {
+    MdcPreset(
+      fields = buildStrings(config, "fields"),
+      requestBodyMaxBytes = if (config.hasPath("request-body-max-bytes")) {
+        Option(config.getInt("request-body-max-bytes"))
+      } else Option.empty,
+      responseBodyMaxBytes = if (config.hasPath("response-body-max-bytes")) {
+        Option(config.getInt("response-body-max-bytes"))
+      } else Option.empty,
+      urls = if (isDefault) Seq.empty[Regex] else buildStrings(config, "urls").map { _.r }
+    )
+  }
+
+  def buildMdcPresets(config: Config): Seq[MdcPreset] = {
+    config
+      .getConfigList("presets")
+      .asScala
+      .map { buildMdcPreset(_, isDefault = false) }
+      .toSeq
   }
 }


### PR DESCRIPTION
This PR introduces two improvements to HTTP client logging:

1. Combined log entry — request and response are logged in a single message instead of two separate ones (configurable).
2. MDC support — adds HTTP request and response details to the logging context (MDC), with configurable fields and optional URL-specific presets.